### PR TITLE
URL Cleanup

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -42,7 +42,7 @@
 		<repository>
 			<id>ratpack-snapshot</id>
 			<name>Ratpack Snapshots</name>
-			<url>http://oss.jfrog.org/artifactory/repo</url>
+			<url>https://oss.jfrog.org/artifactory/repo</url>
 			<snapshots>
 				<enabled>true</enabled>
 			</snapshots>


### PR DESCRIPTION
This commit updates URLs to prefer the https protocol. Redirects are not followed to avoid accidentally expanding intentionally shortened URLs (i.e. if using a URL shortener).

# Fixed URLs

## Fixed But Review Recommended
These URLs were fixed, but the https status was not OK. However, the https status was the same as the http request or http redirected to an https URL, so they were migrated. Your review is recommended.

* http://oss.jfrog.org/artifactory/repo (404) migrated to:  
  https://oss.jfrog.org/artifactory/repo ([https](https://oss.jfrog.org/artifactory/repo) result 404).

# Ignored
These URLs were intentionally ignored.

* http://maven.apache.org/POM/4.0.0
* http://maven.apache.org/xsd/maven-4.0.0.xsd
* http://www.w3.org/2001/XMLSchema-instance